### PR TITLE
Update GHES template.json to disable local auth

### DIFF
--- a/ghes/manifest/template.json
+++ b/ghes/manifest/template.json
@@ -42,6 +42,7 @@
         "endpoint": "[variables('endpoint')]",
         "msaAppId": "[parameters('MicrosoftAppId')]",
         "msaAppType": "MultiTenant"
+        "disableLocalAuth": true
       }
     },
     {

--- a/ghes/manifest/template.json
+++ b/ghes/manifest/template.json
@@ -41,7 +41,7 @@
         "displayName": "GHE",
         "endpoint": "[variables('endpoint')]",
         "msaAppId": "[parameters('MicrosoftAppId')]",
-        "msaAppType": "MultiTenant"
+        "msaAppType": "MultiTenant",
         "disableLocalAuth": true
       }
     },


### PR DESCRIPTION
resolves https://github.com/github/slack/issues/5701

This PR disables local authentication for bots generated from the GHES template. This is not required for the teams integration to operate.