### PR TITLE
Update Readme.md to include link to ghe.com (GHEC with data residency)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -384,7 +384,8 @@ By granting the app access, you are providing the following authorizations to yo
 
 ## GHEC Integration
 
-_documentation is currently work in progress. Learn more about [GitHub Enterprise Cloud with Data Residency](https://docs.github.com/en/enterprise-cloud@latest/admin/data-residency/about-github-enterprise-cloud-with-data-residency)_
+### GHEC with Data Residency (ghe.com)
+The data residency version of the Microsoft Teams app can be installed from AppSource [here](https://appsource.microsoft.com/en-us/product/office/WA200008122). 
 
 ## GHES Integration
 We are announcing GA for GHES integration with Microsoft Teams with GHES 3.8. 


### PR DESCRIPTION
Removed the generic pointer to GHEC w/data residency docs and added the direct link to the AppSource listing for the ghe.com data resident version of the Teams integration.